### PR TITLE
docs: add initial Sphinx documentation structure

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,55 @@
+name: Deploy Sphinx Docs
+
+on:
+  push:
+    branches:
+      - main
+      - dev/documentation
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install documentation dependencies
+        working-directory: docs
+        run: pip install -r requirements.txt
+
+      - name: Build HTML documentation
+        working-directory: docs
+        run: make html
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/build/html
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Sphinx build output
+docs/build/
+
+# Sphinx cache
+docs/source/_build/
+docs/source/.doctrees/
+
+# Python cache
+__pycache__/
+*.pyc
+
+# Virtual environments
+venv/
+.env/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: docs/source/conf.py
+
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx
+sphinx-rtd-theme
+sphinx-copybutton

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1,0 +1,177 @@
+/* =========================================================
+   openENOC Documentation Theme (RTD override)
+   ========================================================= */
+
+/* -------------------------
+   Sidebar background
+------------------------- */
+.wy-side-nav-search,
+.wy-nav-side {
+    background: #111827;
+}
+
+/* -------------------------
+   Logo / title
+------------------------- */
+.wy-side-nav-search > a,
+.wy-side-nav-search .wy-dropdown > a {
+    color: #ffffff !important;
+}
+
+/* -------------------------
+   Search box
+------------------------- */
+.wy-side-nav-search input[type="text"] {
+    border-color: #374151;
+    background: #1f2937;
+    color: #ffffff;
+}
+
+/* -------------------------
+   Default sidebar links
+------------------------- */
+.wy-menu-vertical a {
+    color: #d1d5db !important;
+    background: transparent !important;
+    border-left: 4px solid transparent;
+}
+
+/* -------------------------
+   Top-level (unopened)
+------------------------- */
+.wy-menu-vertical li.toctree-l1 > a {
+    background-color: #111827 !important;
+}
+
+/* -------------------------
+   Top-level (opened section)
+------------------------- */
+.wy-menu-vertical li.toctree-l1.current > a {
+    background-color: #1f2937 !important;
+    color: #ffffff !important;
+    border-left: 4px solid #38bdf8;
+    font-weight: 700;
+}
+
+/* -------------------------
+   Nested container (opened)
+------------------------- */
+.wy-menu-vertical li.toctree-l1.current > ul {
+    background-color: #0b1220 !important;
+    padding-top: 4px;
+    padding-bottom: 6px;
+}
+
+/* -------------------------
+   Nested links
+------------------------- */
+.wy-menu-vertical li.toctree-l2 > a,
+.wy-menu-vertical li.toctree-l3 > a {
+    background-color: #0b1220 !important;
+    color: #cbd5e1 !important;
+    padding-left: 28px;
+}
+
+/* -------------------------
+   Currently selected page
+------------------------- */
+.wy-menu-vertical li.current a.current {
+    background-color: #2563eb !important;
+    color: #ffffff !important;
+    border-left: 4px solid #f97316;
+    font-weight: 600;
+}
+
+/* -------------------------
+   Hover (ALL cases fixed)
+------------------------- */
+.wy-menu-vertical a:hover,
+.wy-menu-vertical li.current > a:hover,
+.wy-menu-vertical li.current a:hover,
+.wy-menu-vertical li.toctree-l1 > a:hover,
+.wy-menu-vertical li.toctree-l2 > a:hover,
+.wy-menu-vertical li.toctree-l3 > a:hover {
+    background-color: #374151 !important;
+    color: #ffffff !important;
+    border-left-color: #38bdf8;
+}
+
+/* -------------------------
+   Focus / active fix
+------------------------- */
+.wy-menu-vertical a:focus,
+.wy-menu-vertical a:active {
+    background-color: #374151 !important;
+    color: #ffffff !important;
+}
+
+/* -------------------------
+   Section titles
+------------------------- */
+.wy-menu-vertical p.caption {
+    color: #9ca3af;
+    font-weight: 600;
+}
+
+/* =========================================================
+   Main content styling
+   ========================================================= */
+
+/* Links */
+.rst-content a {
+    color: #2563eb;
+}
+
+.rst-content a:hover {
+    color: #1d4ed8;
+}
+
+/* Headings */
+.rst-content h1,
+.rst-content h2,
+.rst-content h3 {
+    color: #111827;
+}
+
+/* Code blocks */
+.rst-content code.literal {
+    color: #be123c;
+    background-color: #f3f4f6;
+    border: 1px solid #e5e7eb;
+}
+
+/* Pre blocks */
+.rst-content pre {
+    background: #111827;
+    color: #e5e7eb;
+    border-radius: 6px;
+    padding: 12px;
+}
+
+/* Tables */
+.rst-content table {
+    border: 1px solid #e5e7eb;
+}
+
+.rst-content table th {
+    background: #f3f4f6;
+}
+
+/* =========================================================
+   Small polish
+   ========================================================= */
+
+/* Scrollbar (webkit only) */
+::-webkit-scrollbar {
+    width: 8px;
+}
+
+::-webkit-scrollbar-thumb {
+    background: #374151;
+    border-radius: 4px;
+}
+
+/* Smooth transitions */
+.wy-menu-vertical a {
+    transition: background-color 0.15s ease, color 0.15s ease;
+}

--- a/docs/source/build_docs.rst
+++ b/docs/source/build_docs.rst
@@ -1,0 +1,84 @@
+Build the Documentation
+=======================
+
+This section explains how to build the uberClock documentation locally and how
+it is configured for Read the Docs.
+
+Prerequisites
+-------------
+
+Make sure the following tools are installed on your system:
+
+- Python 3
+- ``venv`` (Python virtual environments)
+- ``make``
+- Sphinx
+
+Setup a Virtual Environment
+---------------------------
+
+Create a virtual environment for building the documentation:
+
+.. code-block:: bash
+
+   python3 -m venv ~/venvs/docs
+
+Activate the environment:
+
+.. code-block:: bash
+
+   source ~/venvs/docs/bin/activate
+
+Install Documentation Dependencies
+----------------------------------
+
+Install the required Python packages:
+
+.. code-block:: bash
+
+   pip install -r 0.doc/docs/requirements.txt
+
+Build the HTML Documentation
+----------------------------
+
+Clone the repository if you have not already done so:
+
+.. code-block:: bash
+
+   git clone <repository-url>
+   cd <repository-folder>
+
+Build the HTML documentation using Sphinx:
+
+.. code-block:: bash
+
+   cd docs
+   make html
+
+After the build finishes, open the generated documentation:
+
+.. code-block:: bash
+
+   xdg-open docs/build/html/index.html
+
+.. note::
+
+   The output HTML files are generated inside the ``build/html`` directory.
+
+Read the Docs
+-------------
+
+The repository includes a ``.readthedocs.yaml`` file at the repository root.
+Read the Docs uses it to:
+
+- build on Ubuntu 24.04
+- use Python 3.11
+- load the Sphinx configuration from ``docs/source/conf.py``
+- install dependencies from ``docs/requirements.txt``
+
+After importing the repository into Read the Docs, the hosted documentation
+will be available at a URL like:
+
+.. code-block:: text
+
+   https://<project-name>.readthedocs.io/

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,37 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'uberClock'
+copyright = '2026,'
+author = 'Enio Kaljić'
+release = '0.0.1'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    "sphinx_copybutton",
+]
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'sphinx_rtd_theme'
+html_logo = '../images/openENOC.logo.svg'
+html_theme_options = {
+    'logo_only': True,
+}
+html_static_path = ['_static']
+html_css_files = [
+    "custom.css",
+]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,40 @@
+Scalable Ethernet-based Network-on-Chip
+=======================================
+
+This documentation currently contains the initial project overview for
+openENOC, including background, goals, architecture motivation, and
+project plan.
+
+As the project evolves, this documentation will be expanded to include
+detailed architecture descriptions, RTL documentation, software APIs,
+verification flows, and build instructions.
+
+Quick links
+-----------
+
+* :doc:`project_overview` - Full project description, goals, and work packages
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Documentation
+
+   project_overview
+   build_docs
+
+Future Sections
+---------------
+
+The documentation is planned to grow into the following areas:
+
+* ``Architecture`` — Ethernet-based NoC design and packet model
+* ``RTL`` — Gateware components and datapath design
+* ``Software`` — HAL, APIs, and runtime control
+* ``Verification`` — Simulation and co-verification flows
+* ``Demo Platforms`` — FPGA integration and system examples
+* ``Toolchains`` — Build and synthesis flows
+
+Indices
+-------
+
+* :ref:`genindex`
+* :ref:`search`

--- a/docs/source/project_overview.rst
+++ b/docs/source/project_overview.rst
@@ -1,0 +1,158 @@
+.. SPDX-FileCopyrightText: 2026 Enio Kaljic
+.. SPDX-License-Identifier: CC-BY-SA-4.0
+
+Scalable Ethernet-based Network-on-Chip
+=======================================
+
+Overview
+--------
+
+**openENOC** is an open-source hardware and software initiative that develops a modular and scalable Ethernet-based Network-on-Chip (NoC) architecture for FPGA SoCs and advanced MPSoC designs.
+
+By adopting standard Ethernet Layer 2 as the native on-chip transport protocol, rather than relying on traditional mesh or proprietary interconnects, openENOC enables seamless integration with existing Ethernet infrastructure and establishes a unified communication and programming model across both on-chip and off-chip systems.
+
+.. image:: ../images/openENOC.logo.svg
+   :width: 25%
+   :align: center
+
+This approach allows processors, accelerators, and peripherals to be connected through a flexible, packet-switched network based on L2 switching, effectively bridging the gap between on-chip and off-chip networking while lowering the complexity of building large-scale systems.
+
+Background
+----------
+
+The concept originated from practical challenges encountered during the development of the NLnet-funded `WireGuard FPGA project
+<https://nlnet.nl/project/KlusterLab-Wireguard/>`_, where scaling cryptographic workloads such as Curve25519 and ChaCha20-Poly1305 exposed limitations of conventional interconnect architectures.
+
+In response, openENOC introduces an Ethernet-based interconnect designed to
+support efficient, network-oriented scaling of cryptographic processing, edge
+computing, and AI acceleration workloads.
+
+Goals
+-----
+
+openENOC aims to deliver a complete, freely licensed full-stack solution
+combining reusable hardware and software gateware developed in SystemVerilog
+and C/C++.
+
+The project will provide RTL components, integration APIs, verification
+infrastructure, and reference designs, forming a cohesive and production-ready
+foundation.
+
+Its primary goal is to unlock the potential of networked reconfigurable
+computing by making it accessible, portable, and adaptable across a wide range
+of use cases.
+
+All results will be released openly to encourage reuse, strengthen the open
+hardware ecosystem, and empower developers and organizations to build
+interoperable, future-proof, and community-driven MPSoC solutions.
+
+Project Plan
+------------
+
+The project is organized around `four global milestones (M1-M4)
+<https://github.com/eniokaljic/openENOC/milestones>`_ representing successive
+development phases of the openENOC platform: architecture definition,
+functional prototyping, system integration, and final platform release.
+
+.. image:: ../images/ProjectExecutionPlan.png
+   :width: 100%
+   :align: center
+
+This structure ensures that hardware development, software integration,
+verification, tooling, and documentation progress in parallel throughout the
+project.
+
+Work Packages
+-------------
+
+WP1 - RTL Gateware Development
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This work package delivers the complete openENOC RTL implementation forming the
+hardware datapath of the Ethernet-based Network-on-Chip.
+
+* ☐ `RTL1 - Core Switching Primitives <https://github.com/eniokaljic/openENOC/issues/1>`_
+* ☐ `RTL2 - Packet Processing Pipeline <https://github.com/eniokaljic/openENOC/issues/2>`_
+* ☐ `RTL3 - Forwarding & DMA Engines <https://github.com/eniokaljic/openENOC/issues/3>`_
+* ☐ `RTL4 - Integrated NoC Fabric <https://github.com/eniokaljic/openENOC/issues/4>`_
+
+WP2 - Integration HAL and Software API Development
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This work package provides the software interface layer required to configure
+and control the NoC.
+
+* ☐ `SW1 - HAL Architecture Specification <https://github.com/eniokaljic/openENOC/issues/5>`_
+* ☐ `SW2 - RISC-V Platform Integration <https://github.com/eniokaljic/openENOC/issues/6>`_
+* ☐ `SW3 - Runtime Control API <https://github.com/eniokaljic/openENOC/issues/7>`_
+* ☐ `SW4 - Reference Applications <https://github.com/eniokaljic/openENOC/issues/8>`_
+
+WP3 - Verification Infrastructure Development
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This work package establishes the verification infrastructure required to
+validate both the hardware and software components of the platform.
+
+* ☐ `DV1 - Simulation Framework <https://github.com/eniokaljic/openENOC/issues/9>`_
+* ☐ `DV2 - Module-Level Verification <https://github.com/eniokaljic/openENOC/issues/10>`_
+* ☐ `DV3 - HW/SW Co-Verification <https://github.com/eniokaljic/openENOC/issues/11>`_
+* ☐ `DV4 - Continuous Verification Infrastructure <https://github.com/eniokaljic/openENOC/issues/12>`_
+
+WP4 - Demo SoCs and Educational Kits Development
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This work package demonstrates the practical applicability of openENOC through
+deployable FPGA-based systems.
+
+* ☐ `DEM1 - Initial FPGA NoC Demo <https://github.com/eniokaljic/openENOC/issues/13>`_
+* ☐ `DEM2 - Extended FPGA Demonstration Platform <https://github.com/eniokaljic/openENOC/issues/14>`_
+
+WP5 - FOSS Synthesis & PnR Toolchains Integration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This work package ensures that openENOC can be built using a fully open-source
+FPGA toolchain.
+
+* ☐ `PNR1 - Open Synthesis Flow <https://github.com/eniokaljic/openENOC/issues/19>`_
+* ☐ `PNR2 - Automated Bitstream Build Flow <https://github.com/eniokaljic/openENOC/issues/20>`_
+
+WP6 - Repository & Documentation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This work package produces the technical documentation and developer resources
+necessary to make the project accessible and reusable by the wider open
+hardware community.
+
+* ☐ `DOC1 - Initial Architecture Documentation <https://github.com/eniokaljic/openENOC/issues/15>`_
+* ☐ `DOC2 - Design Documentation <https://github.com/eniokaljic/openENOC/issues/16>`_
+* ☐ `DOC3 - Tutorials & Developer Guides <https://github.com/eniokaljic/openENOC/issues/17>`_
+* ☐ `DOC4 - Reproducible Build & Verification Documentation <https://github.com/eniokaljic/openENOC/issues/18>`_
+
+WP7 - Results Dissemination
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This work package focuses on communicating the results of the project to the
+broader open hardware and research communities.
+
+* ☐ `DIS1 - Technical Publication <https://github.com/eniokaljic/openENOC/issues/21>`_
+* ☐ `DIS2 - Conference Presentation <https://github.com/eniokaljic/openENOC/issues/22>`_
+
+Acknowledgements
+----------------
+
+We are grateful to **NLnet Foundation** for their sponsorship of this
+development activity.
+
+.. image:: https://nlnet.nl/logo/banner.svg
+   :width: 25%
+   :align: center
+
+.. image:: https://nlnet.nl/image/logos/NGI0Core_tag.svg
+   :width: 25%
+   :align: center
+
+This project was funded through the NGI0 Commons Fund, a fund established by
+NLnet with financial support from the European Commission's Next Generation
+Internet programme, under the aegis of DG Communications Networks, Content and
+Technology under grant agreement No. 101135429. Additional funding is made
+available by the Swiss State Secretariat for Education, Research and Innovation.


### PR DESCRIPTION
## Description
This PR adds the initial project documentation setup for openENOC.

## Changes
- Add project overview documentation
- Configure Sphinx build system
- Add custom theme styling
- Add documentation build instructions
- Setup initial index and navigation
- Added CD for github-pages
- Added readthedocs.yaml file

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing
Documentation builds successfully with `make html`. All links verified.

## How to Test
1. Checkout this branch: `git checkout docs/initial-documentation`
2. Build docs: `cd docs && make html`
3. Open `docs/_build/html/index.html` in browser

## Additional Notes
This is the initial documentation setup. Future PRs will add more detailed content.